### PR TITLE
remove enzyme libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.6",
     "google-map-react": "^2.1.10",
     "node-postcodes.io": "^1.0.3",
     "react": "^17.0.2",


### PR DESCRIPTION
reason: they had caused netlify to fail.

netlify deployed correctly now.